### PR TITLE
Fix hashtags

### DIFF
--- a/app/src/pages/Homefeed/index.js
+++ b/app/src/pages/Homefeed/index.js
@@ -208,7 +208,7 @@ export default function HomeFeed() {
 
             const newTags = tags.filter(tag => !existingTags.includes(tag.toLowerCase()));
             await Promise.all(newTags.map(async (tag) => {
-                const docId = ` ${userId}_${tag.toLowerCase()}_${selectedPhoto.group_id}`;
+                const docId = `${userId}_${tag.toLowerCase()}_${selectedPhoto.group_id}`;
                 const settingRef = doc(db, 'user_hashtag_settings', docId);
                 await setDoc(settingRef, {
                     user_id: userId,

--- a/app/src/pages/Homefeed/index.js
+++ b/app/src/pages/Homefeed/index.js
@@ -208,7 +208,7 @@ export default function HomeFeed() {
 
             const newTags = tags.filter(tag => !existingTags.includes(tag.toLowerCase()));
             await Promise.all(newTags.map(async (tag) => {
-                const docId = `${userId}_${tag.toLowerCase()}`;
+                const docId = ` ${userId}_${tag.toLowerCase()}_${selectedPhoto.group_id}`;
                 const settingRef = doc(db, 'user_hashtag_settings', docId);
                 await setDoc(settingRef, {
                     user_id: userId,

--- a/app/src/pages/Post/index.js
+++ b/app/src/pages/Post/index.js
@@ -107,7 +107,7 @@ export default function Post() {
                 // 追加: ユーザのハッシュタグ設定を保存（ON状態）
                 const userId = auth.currentUser.uid;
                 await Promise.all(tags.map(async (tag) => {
-                    const docId = `${userId}_${tag.toLowerCase()}`;
+                    const docId = ` ${userId}_${tag.toLowerCase()}_${selectedGroup.id}`;
                     const settingRef = doc(db, 'user_hashtag_settings', docId);
                     await setDoc(settingRef, {
                         user_id: userId,

--- a/app/src/pages/Post/index.js
+++ b/app/src/pages/Post/index.js
@@ -107,7 +107,7 @@ export default function Post() {
                 // 追加: ユーザのハッシュタグ設定を保存（ON状態）
                 const userId = auth.currentUser.uid;
                 await Promise.all(tags.map(async (tag) => {
-                    const docId = ` ${userId}_${tag.toLowerCase()}_${selectedGroup.id}`;
+                    const docId = `${userId}_${tag.toLowerCase()}_${selectedGroup.id}`;
                     const settingRef = doc(db, 'user_hashtag_settings', docId);
                     await setDoc(settingRef, {
                         user_id: userId,

--- a/app/src/pages/Post/index.js
+++ b/app/src/pages/Post/index.js
@@ -112,6 +112,7 @@ export default function Post() {
                     await setDoc(settingRef, {
                         user_id: userId,
                         hashtag: tag.toLowerCase(),
+                        group_id: selectedGroup.id,
                         show_in_feed: true,
                         updated_at: new Date(),
                     }, { merge: true });

--- a/app/src/pages/Post/index.js
+++ b/app/src/pages/Post/index.js
@@ -1,7 +1,7 @@
 import { useLocation, useNavigate } from 'react-router-dom';
 import { useEffect, useState } from 'react';
 import { db, storage, auth } from '../../firebase';
-import { collection, addDoc, serverTimestamp, getDocs, doc } from 'firebase/firestore';
+import { collection, addDoc, serverTimestamp, getDocs, setDoc, doc } from 'firebase/firestore'; 
 import { ref, uploadBytes, getDownloadURL } from 'firebase/storage';
 
 export default function Post() {
@@ -61,23 +61,8 @@ export default function Post() {
         setYear(e.target.value);
       };
     
-    const saveHashtagsToFirestore = async (photoId) => {
-        const hashtagPromises = tags.map((tag) =>
-            addDoc(collection(db, 'hashtags'), {
-                user_id: auth.currentUser?.uid,
-                group_id: selectedGroup?.id,
-                hashtag: tag.toLowerCase(),
-                show_in_feed: false,
-                created_at: serverTimestamp(),
-                photo_id: photoId,
-            })
-        );
-        await Promise.all(hashtagPromises);
-    };
-
     // post
     const handleUpload = async () => {
-        console.log('Upload started');
 
         // validation check
         const newErrors = [];
@@ -92,9 +77,10 @@ export default function Post() {
         setErrors(newErrors);
         if (newErrors.length > 0) return;
 
-        // upload
         try {
             setIsLoading(true);
+
+            // upload to Cloudinary
             const formData = new FormData();
             formData.append('image', files[0]);
 
@@ -104,22 +90,32 @@ export default function Post() {
             });
 
             if (!response.ok) throw new Error('Upload failed.');
-
             const data = await response.json();
-            console.log('Upload successful:', data);
 
-            // save in firestore
             if (data.url) {
+                // save photo in Firestore
                 const photoData = {
                     photo_url: data.url,
-                    group_id: selectedGroup?.id,
+                    group_id: selectedGroup.id,
                     year: year || null,
-                    hashtags: tags,
+                    hashtags: tags.map(tag => tag.toLowerCase()),
                     created_at: serverTimestamp(),
                 };
 
-                const photoDocRef = await addDoc(collection(db, 'photos'), photoData);
-                await saveHashtagsToFirestore(photoDocRef.id);
+                await addDoc(collection(db, 'photos'), photoData);
+
+                // 追加: ユーザのハッシュタグ設定を保存（ON状態）
+                const userId = auth.currentUser.uid;
+                await Promise.all(tags.map(async (tag) => {
+                    const docId = `${userId}_${tag.toLowerCase()}`;
+                    const settingRef = doc(db, 'user_hashtag_settings', docId);
+                    await setDoc(settingRef, {
+                        user_id: userId,
+                        hashtag: tag.toLowerCase(),
+                        show_in_feed: true,
+                        updated_at: new Date(),
+                    }, { merge: true });
+                }));
 
                 alert('Upload and save complete!');
                 navigate('/home');
@@ -151,12 +147,6 @@ export default function Post() {
             navigate(-1);
         }
     }, [files, navigate]);
-
-    const mockGroups = [
-        { id: '1', name: 'Family' },
-        { id: '2', name: 'Friends' },
-        { id: '3', name: 'Work' },
-    ];
 
     return (
         <div className="flex flex-col items-center justify-center min-h-screen bg-[#A5C3DE] text-[#0A4A6E] px-4 relative">

--- a/app/src/pages/User/Hashtags.js
+++ b/app/src/pages/User/Hashtags.js
@@ -1,6 +1,6 @@
 import { useEffect, useState } from 'react';
 import { useNavigate } from 'react-router-dom';
-import { collection, query, where, getDocs, updateDoc, doc } from 'firebase/firestore';
+import { collection, query, where, getDocs, setDoc, doc, updateDoc } from 'firebase/firestore'; 
 import { auth, db } from '../../firebase';
 
 export default function Hashtags() {
@@ -15,16 +15,45 @@ export default function Hashtags() {
         const fetchHashtags = async () => {
             if (!auth.currentUser) return;
             try {
-                const q = query(
-                    collection(db, 'hashtags'),
-                    where('user_id', '==', auth.currentUser.uid)
+                // 所属グループ取得
+                const groupSnapshot = await getDocs(query(
+                    collection(db, 'groups'),
+                    where('members', 'array-contains', auth.currentUser.uid)
+                ));
+                const groupIds = groupSnapshot.docs.map(doc => doc.id);
+
+                if (groupIds.length === 0) {
+                    setHashtags([]);
+                    return;
+                }
+
+                // 各グループの user_hashtag_settings を取得
+                const promises = groupIds.map(groupId =>
+                    getDocs(query(
+                        collection(db, 'user_hashtag_settings'),
+                        where('group_id', '==', groupId)
+                    ))
                 );
-                const snapshot = await getDocs(q);
-                const hashtagsData = snapshot.docs.map(doc => ({
-                    id: doc.id,
-                    ...doc.data(),
-                }));
-                setHashtags(hashtagsData);
+                const snapshots = await Promise.all(promises);
+
+                let allSettings = [];
+                snapshots.forEach(snapshot => {
+                    snapshot.docs.forEach(doc => {
+                        allSettings.push({ id: doc.id, ...doc.data() });
+                    });
+                });
+
+                // 同じハッシュタグが複数あった場合は自分の設定を優先
+                const uniqueHashtagsMap = {};
+                allSettings.forEach(setting => {
+                    const tag = setting.hashtag;
+                    if (!uniqueHashtagsMap[tag] || setting.user_id === auth.currentUser.uid) {
+                        uniqueHashtagsMap[tag] = setting;
+                    }
+                });
+
+                const mergedData = Object.values(uniqueHashtagsMap);
+                setHashtags(mergedData);
             } catch (error) {
                 console.error('Error fetching hashtags:', error);
                 setErrors(['Failed to load hashtags.']);
@@ -35,8 +64,8 @@ export default function Hashtags() {
 
         fetchHashtags();
     }, []);
-
-    // hashtag swutches
+    
+    // hashtag switches
     const toggleShowInFeed = (index) => {
         const updated = [...hashtags];
         updated[index].show_in_feed = !updated[index].show_in_feed;
@@ -52,9 +81,15 @@ export default function Hashtags() {
         try {
             await Promise.all(
                 hashtags.map(async (hashtag) => {
-                    await updateDoc(doc(db, 'hashtags', hashtag.id), {
+                    const docId = `${auth.currentUser.uid}_${hashtag.hashtag}`;
+                    const userSettingRef = doc(db, 'user_hashtag_settings', docId);
+                    await setDoc(userSettingRef, {
+                        user_id: auth.currentUser.uid,
+                        hashtag: hashtag.hashtag,
+                        group_id: hashtag.group_id,
                         show_in_feed: hashtag.show_in_feed,
-                    });
+                        updated_at: new Date(),
+                    }, { merge: true });
                 })
             );
             setSuccessMessage('Hashtags updated successfully!');

--- a/app/src/pages/User/Hashtags.js
+++ b/app/src/pages/User/Hashtags.js
@@ -96,15 +96,25 @@ export default function Hashtags() {
         try {
             await Promise.all(
                 hashtags.map(async (hashtag) => {
-                    const docId = `${auth.currentUser.uid}_${hashtag.hashtag}`;
-                    const userSettingRef = doc(db, 'user_hashtag_settings', docId);
-                    await setDoc(userSettingRef, {
-                        user_id: auth.currentUser.uid,
-                        hashtag: hashtag.hashtag,
-                        group_id: hashtag.group_id,
-                        show_in_feed: hashtag.show_in_feed,
-                        updated_at: new Date(),
-                    }, { merge: true });
+                    // user_id と hashtag で複数のレコード取得
+                    const q = query(
+                        collection(db, 'user_hashtag_settings'),
+                        where('user_id', '==', auth.currentUser.uid),
+                        where('hashtag', '==', hashtag.hashtag)
+                    );
+                    const snapshot = await getDocs(q);
+
+                    // それぞれのレコードを更新
+                    await Promise.all(snapshot.docs.map(docSnapshot => {
+                        const userSettingRef = doc(db, 'user_hashtag_settings', docSnapshot.id);
+                        return setDoc(userSettingRef, {
+                            user_id: auth.currentUser.uid,
+                            hashtag: hashtag.hashtag,
+                            group_id: docSnapshot.data().group_id, // 既存のgroup_idを維持
+                            show_in_feed: hashtag.show_in_feed,
+                            updated_at: new Date(),
+                        }, { merge: true });
+                    }));
                 })
             );
             setSuccessMessage('Hashtags updated successfully!');


### PR DESCRIPTION
#17 
### when uploading new photo

- save info `photos` collection as before
- save hashtags into `user_hashtag_settings` collection instead old collection hastags

### when editing hashtags

- uodated info in `photos` and `user_hashtag_settings` collection if the hashtags are new

### when managing hashtags

- show all hashtags that belongs to all your group
- modify show/hide in `user_hashtag_settings` collection by each user individually

### in home feed

- show hashtags that user set show in `user_hashtag_settings` collection

### user_hashtag_settings collection

- `hashtag`
- `show_in_feed`
- `user_id`
- `group_id`
- `updated_at`